### PR TITLE
Initialize Next.js scaffold with Supabase auth and Stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key
+STRIPE_SECRET_KEY=your-stripe-secret-key

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -49,3 +49,19 @@
 ### 7. Email Notifications
 - Email alert when a new client submits a form
 - Optional: include the AI summary in the email
+
+## Setup
+
+Install dependencies (requires Node.js and npm):
+
+```bash
+npm install
+```
+
+Create an `.env` file based on `.env.example` and add your Supabase and Stripe keys.
+
+Run the development server:
+
+```bash
+npm run dev
+```

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+}
+
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "client-intake",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.38.5",
+    "@stripe/stripe-js": "2.3.0",
+    "stripe": "12.16.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.2",
+    "tailwindcss": "3.4.4",
+    "postcss": "8.4.38",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/app/api/stripe/route.ts
+++ b/src/app/api/stripe/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import Stripe from 'stripe'
+
+const stripeSecret = process.env.STRIPE_SECRET_KEY as string
+
+const stripe = new Stripe(stripeSecret, {
+  apiVersion: '2023-10-16'
+})
+
+export async function POST(req: NextRequest) {
+  const { priceId } = await req.json()
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${req.nextUrl.origin}/?success=true`,
+      cancel_url: `${req.nextUrl.origin}/?canceled=true`
+    })
+
+    return NextResponse.json({ sessionId: session.id })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+import { supabase } from '@/utils/supabaseClient'
+import { useRouter } from 'next/navigation'
+
+export default function Login() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleEmailLogin = async () => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/')
+    }
+  }
+
+  const handleGoogleLogin = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' })
+    if (error) {
+      setError(error.message)
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4 space-y-4">
+      <div className="flex flex-col space-y-2">
+        <input
+          className="border px-2 py-1"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border px-2 py-1"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button onClick={handleEmailLogin} className="bg-blue-500 text-white p-2 rounded">
+          Log in with Email
+        </button>
+        <button onClick={handleGoogleLogin} className="bg-red-500 text-white p-2 rounded">
+          Continue with Google
+        </button>
+        {error && <p className="text-red-600">{error}</p>}
+      </div>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { supabase } from '@/utils/supabaseClient'
+import Link from 'next/link'
+
+export default function Home() {
+  const [userEmail, setUserEmail] = useState<string | null>(null)
+
+  useEffect(() => {
+    const { data: { session } } = supabase.auth.getSession()
+    session.then(res => {
+      setUserEmail(res.session?.user.email ?? null)
+    })
+  }, [])
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    setUserEmail(null)
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
+      {userEmail ? (
+        <div className="space-y-4 text-center">
+          <p className="text-lg">Logged in as {userEmail}</p>
+          <button onClick={handleLogout} className="px-4 py-2 bg-red-500 text-white rounded">Logout</button>
+        </div>
+      ) : (
+        <Link href="/login" className="px-4 py-2 bg-blue-500 text-white rounded">Login</Link>
+      )}
+    </main>
+  )
+}

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx,mdx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js app with TypeScript and Tailwind
- add Supabase client setup and login page with email & Google auth
- create simple home screen that shows session info
- configure Stripe checkout API route
- document environment variables and setup instructions

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: next not found since dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882854e2a68832381acc9ae6bfcef25